### PR TITLE
Disable type validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 build/
 .gradle/
+.idea/
+/.idea/codeStyles/codeStyleConfig.xml
+/.idea/compiler.xml
+/.idea/gradle.xml
+/.idea/jarRepositories.xml
+/.idea/misc.xml
+/.idea/runConfigurations.xml
+/.idea/vcs.xml

--- a/examples/kotlin/src/main/kotlin/io/github/joke/spockmockable/Address.kt
+++ b/examples/kotlin/src/main/kotlin/io/github/joke/spockmockable/Address.kt
@@ -1,3 +1,3 @@
 package io.github.joke.spockmockable
 
-data class Address(var street: String? = "Murder Lane")
+data class Address(var street: String? = "Murder Lane", var city: String?)

--- a/examples/kotlin/src/main/kotlin/io/github/joke/spockmockable/Company.kt
+++ b/examples/kotlin/src/main/kotlin/io/github/joke/spockmockable/Company.kt
@@ -1,0 +1,13 @@
+package io.github.joke.spockmockable
+
+class Company(val name: String, val city: String) {
+    private val employees = mutableListOf<Person>()
+
+    fun hire(candidates: List<Person>): List<Person> {
+        employees.addAll(candidates)
+        // the predicate lambda is compiled to private static method with special characters in the name
+        // which triggers an  Illegal method name boolean  because byte-buddy is too strict
+        employees.removeIf { person -> person.address.street != this.city }
+        return employees
+    }
+}

--- a/examples/kotlin/src/test/groovy/io/github/joke/spockmockable/CompanyTest.groovy
+++ b/examples/kotlin/src/test/groovy/io/github/joke/spockmockable/CompanyTest.groovy
@@ -1,0 +1,40 @@
+package io.github.joke.spockmockable
+
+import org.spockframework.mock.MockUtil
+import spock.lang.Specification
+
+@Mockable(Company)
+class CompanyTest extends Specification {
+    def mockUtil = new MockUtil()
+
+    def 'final class is mocked'() {
+        given: 'a company mock'
+        Company company = Mock()
+
+        expect: 'instance is mocked'
+        mockUtil.isMock(company)
+    }
+
+    def 'final modifier from method which contains a lambda is public'() {
+        given: 'a company mock'
+        Company company = Mock() {
+            hire(_) >> [new Person('Harley', 'Quinn', new Address('New Jersey Street', 'Gotham City'))]
+        }
+
+        and: 'a bunch of people looking to be hired'
+        def wantingToBeHired = [
+                new Person('Kal', 'El', new Address('Delaware Street', 'Metropolis')),
+                new Person('Bruce', 'Wayne', new Address('New York Street', 'Gotham City'))]
+
+        when: 'the company tries to hire some people'
+        def hired = company.hire(wantingToBeHired)
+
+        then:
+        with(hired) {
+            assert size() == 1
+            assert get(0).firstName == 'Harley'
+            assert get(0).lastName == 'Quinn'
+            assert get(0).address.city == 'Gotham City'
+        }
+    }
+}

--- a/examples/kotlin/src/test/groovy/io/github/joke/spockmockable/PersonTest.groovy
+++ b/examples/kotlin/src/test/groovy/io/github/joke/spockmockable/PersonTest.groovy
@@ -52,7 +52,7 @@ class PersonTest extends Specification {
         def res = person.address.street
 
         then:
-        1 * person.address >> new Address('Yellow Brick Road')
+        1 * person.address >> new Address('Yellow Brick Road', 'Blue City')
 
         expect:
         res == 'Yellow Brick Road'

--- a/examples/kotlin/src/test/groovy/io/github/joke/spockmockable/PersonTest.groovy
+++ b/examples/kotlin/src/test/groovy/io/github/joke/spockmockable/PersonTest.groovy
@@ -30,7 +30,7 @@ class PersonTest extends Specification {
         res == 'Dorothy'
     }
 
-    def 'privat on method is now protected'() {
+    def 'private on method is now protected'() {
         setup:
         Person person = Mock()
 
@@ -44,7 +44,7 @@ class PersonTest extends Specification {
         res == 'Gale'
     }
 
-    def 'final is removed and privat on method is now protected'() {
+    def 'final is removed and private on method is now protected'() {
         setup:
         Person person = Mock()
 

--- a/examples/spock13/src/test/groovy/io/github/joke/spockmockable/PersonTest.groovy
+++ b/examples/spock13/src/test/groovy/io/github/joke/spockmockable/PersonTest.groovy
@@ -38,7 +38,7 @@ class PersonTest extends Specification {
         res == 'Dorothy'
     }
 
-    def 'privat on method is now protected'() {
+    def 'private on method is now protected'() {
         setup:
         Person person = Mock()
 
@@ -52,7 +52,7 @@ class PersonTest extends Specification {
         res == 'Gale'
     }
 
-    def 'final is removed and privat on method is now protected'() {
+    def 'final is removed and private on method is now protected'() {
         setup:
         Person person = Mock()
 

--- a/examples/spock13/src/test/groovy/io/github/joke/spockmockable/PersonTestWithInheritance.groovy
+++ b/examples/spock13/src/test/groovy/io/github/joke/spockmockable/PersonTestWithInheritance.groovy
@@ -36,7 +36,7 @@ class PersonTestWithInheritance extends TestBase {
         res == 'Dorothy'
     }
 
-    def 'privat on method is now protected'() {
+    def 'private on method is now protected'() {
         setup:
         Person person = Mock()
 
@@ -50,7 +50,7 @@ class PersonTestWithInheritance extends TestBase {
         res == 'Gale'
     }
 
-    def 'final is removed and privat on method is now protected'() {
+    def 'final is removed and private on method is now protected'() {
         setup:
         Person person = Mock()
 

--- a/examples/spock20/src/test/groovy/io/github/joke/spockmockable/PersonTest.groovy
+++ b/examples/spock20/src/test/groovy/io/github/joke/spockmockable/PersonTest.groovy
@@ -38,7 +38,7 @@ class PersonTest extends Specification {
         res == 'Dorothy'
     }
 
-    def 'privat on method is now protected'() {
+    def 'private on method is now protected'() {
         setup:
         Person person = Mock()
 
@@ -52,7 +52,7 @@ class PersonTest extends Specification {
         res == 'Gale'
     }
 
-    def 'final is removed and privat on method is now protected'() {
+    def 'final is removed and private on method is now protected'() {
         setup:
         Person person = Mock()
 

--- a/spock-mockable/src/main/java/io/github/joke/spockmockable/internal/MockableExtension.java
+++ b/spock-mockable/src/main/java/io/github/joke/spockmockable/internal/MockableExtension.java
@@ -1,5 +1,6 @@
 package io.github.joke.spockmockable.internal;
 
+import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.agent.builder.AgentBuilder.InitializationStrategy;
@@ -9,6 +10,7 @@ import net.bytebuddy.description.modifier.MethodManifestation;
 import net.bytebuddy.description.modifier.TypeManifestation;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.scaffold.TypeValidation;
 import net.bytebuddy.utility.JavaModule;
 import org.slf4j.Logger;
 import org.spockframework.runtime.extension.AbstractGlobalExtension;
@@ -74,12 +76,12 @@ public class MockableExtension extends AbstractGlobalExtension {
         properties.load(stream);
 
         return Stream.of(properties.getProperty("classes", "")
-                .split(","))
+                        .split(","))
                 .collect(toSet());
     }
 
     private static void buildAndInstallTransformer(final Set<String> classes) {
-        new AgentBuilder.Default()
+        new AgentBuilder.Default(new ByteBuddy().with(TypeValidation.DISABLED))
                 .ignore(none())
                 .with(new InstallationListener())
                 .with(new DiscoveryListener())


### PR DESCRIPTION
I've recently encountered some Kotlin code implementing Java Predicates as lamdas. At compile time Kotlin transforms the lamdas into static method names that contain special characters that are not allowed by Java standards (but allowed by JVM  specifications). Byte-Buddy agent seems to be very aggressive in the validation and "refuses" to modify methods with special characters.

This PR disables the type validation for the default agent.     