### PR TITLE
Remove with(RETRANSFORMATION) to fix issue with type not being picked up

### DIFF
--- a/spock-mockable/src/main/java/io/github/joke/spockmockable/internal/MockableExtension.java
+++ b/spock-mockable/src/main/java/io/github/joke/spockmockable/internal/MockableExtension.java
@@ -29,7 +29,6 @@ import static java.lang.Boolean.parseBoolean;
 import static java.lang.System.getProperty;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
-import static net.bytebuddy.agent.builder.AgentBuilder.RedefinitionStrategy.RETRANSFORMATION;
 import static net.bytebuddy.agent.builder.AgentBuilder.TypeStrategy.Default.REDEFINE;
 import static net.bytebuddy.description.modifier.Visibility.PROTECTED;
 import static net.bytebuddy.matcher.ElementMatchers.isFinal;
@@ -102,7 +101,6 @@ public class MockableExtension extends AbstractGlobalExtension {
                 .with(new InstallationListener())
                 .with(new DiscoveryListener())
                 .with(InitializationStrategy.NoOp.INSTANCE)
-                .with(RETRANSFORMATION)
                 .with(REDEFINE)
                 .type(typeDescription -> isNotATest(typeDescription) && (isInClasses(classes, typeDescription) || isInPackages(packages, typeDescription)))
                 .transform(MockableExtension::transform)


### PR DESCRIPTION
Sorry I haven't added a test, I don't know how to reproduce the bug and it occurs in a private project. I am happy to provide more information or help debug if you have any guidance to investigate further.

I included in this library to mock some Kotlin classes, and it was working fine except for this one class which I could NOT mock.

```
org.spockframework.mock.CannotCreateMockException: Cannot create mock for class MyClass because Java mocks cannot mock final classes. If the code under test is written in Groovy, use a Groovy mock.
    at app//org.spockframework.mock.runtime.JavaMockFactory.createInternal(JavaMockFactory.java:48)
    at app//org.spockframework.mock.runtime.JavaMockFactory.create(JavaMockFactory.java:38)
    at app//org.spockframework.mock.runtime.CompositeMockFactory.create(CompositeMockFactory.java:42)
    at app//org.spockframework.lang.SpecInternals.createMock(SpecInternals.java:47)
    at app//org.spockframework.lang.SpecInternals.createMockImpl(SpecInternals.java:302)
    at app//org.spockframework.lang.SpecInternals.createMockImpl(SpecInternals.java:292)
    at app//org.spockframework.lang.SpecInternals.MockImpl(SpecInternals.java:101)
```

After cloning it, I imported the project directly and edited

```diff
-                .type(typeDescription -> isNotATest(typeDescription) && (isInClasses(classes, typeDescription) || isInPackages(packages, typeDescription)))
+                .type(typeDescription -> {
+                    boolean result = isNotATest(typeDescription) && (isInClasses(classes, typeDescription) || isInPackages(packages, typeDescription));
+                    if (result) {
+                        System.out.println("Mockable " + typeDescription.getCanonicalName());
+                    } else {
+                        System.out.println("Not mockable " + typeDescription.getCanonicalName());
+                    }
+                    return result;
+                })
```

But the logs showed no evidence of my class going through the predicate at all.

I tried checking if the class was loaded before the transformer was installed

```
var m = ClassLoader.class.getDeclaredMethod("findLoadedClass", new Class[]{String.class});
m.setAccessible(true);
var cl = ClassLoader.getSystemClassLoader();
var existingClass = m.invoke(cl, "MyClass");
System.out.println("Is it already loaded? " + (existingClass != null));
```

And the class in question was NOT loaded.

Only after making this tweak in the PR was I able to see `Mockable MyClass` in the logs and pass the test.